### PR TITLE
allow to specify process_name for group of processes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 
 supervisor_version: 3.0b2-1 
 supervisor_environment: { }
+supervisor_process_name: '%(program_name)s'

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -1,6 +1,6 @@
 [program:{{supervisor_program}}]
 command={{supervisor_command}}
-process_name={{supervisor_process_name|default('%(program_name)s')}}
+process_name={{supervisor_process_name}}
 numprocs={{supervisor_numprocs|default(1)}}
 directory={{supervisor_directory|default('/tmp')}}
 umask={{supervisor_umask|default('022')}}

--- a/templates/supervisor.conf.j2
+++ b/templates/supervisor.conf.j2
@@ -1,6 +1,6 @@
 [program:{{supervisor_program}}]
 command={{supervisor_command}}
-process_name=%(program_name)s
+process_name={{supervisor_process_name|default('%(program_name)s')}}
 numprocs={{supervisor_numprocs|default(1)}}
 directory={{supervisor_directory|default('/tmp')}}
 umask={{supervisor_umask|default('022')}}


### PR DESCRIPTION
In new Fulfillment Importer we need to start several processes of our python app.
to support this supervisor config should specify template for process name.
i've added ability to specify it.
Could you please look into this @sapiensantiquus or @farrellit ? 
Also is this possible to download new build of this playbook from S3 or we are forced to do so from Ansible Galaxy (or what)