### PR TITLE
Add retry to restart handler to fix race condition

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,7 @@
 # handlers file for example
 - name: restart supervisor
   service: name=supervisor state=restarted
+  register: supervisor_restarted
+  until: supervisor_restarted|success
+  retries: 5
+  delay: 5


### PR DESCRIPTION
It seems in the new AMIs there is an occasional race condition that may
cause the supervisor restart to fail. Maybe a retry will help.