### PR TITLE
Leverage sleep option of ansible service module to control restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ inventory/groups
 roles/pip
 VERSION
 roles/supervisor/VERSION
+.idea
+*.iml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 supervisor_version: 3.0b2-1 
 supervisor_environment: { }
 supervisor_process_name: '%(program_name)s'
+supervisor_restart_sleep: 5  # Version of supervisor above defaults to 5 second sleep between stop and start in /etc/init.d/supervisor ($DODTIME)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,5 +6,5 @@
     sleep: "{{ supervisor_restart_sleep | default(omit) }}"
   register: supervisor_restarted
   until: supervisor_restarted|success
-  retries: 5
+  retries: 1
   delay: 5

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: restart supervisor
-  service: name=supervisor state=restarted
+  service:
+    name: supervisor
+    state: restarted
+    sleep: "{{ supervisor_restart_sleep | default(omit) }}"
   register: supervisor_restarted
   until: supervisor_restarted|success
   retries: 5

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-# handlers file for example
 - name: restart supervisor
   service: name=supervisor state=restarted
   register: supervisor_restarted

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,1 @@
 ---
-# vars file for example


### PR DESCRIPTION
Lately we've been running into issues where supervisor fails to start on some of our deployments.
```
TASK: [restart supervisor] ****************************************************
failed: [172.17.0.8] => {"failed": true}
msg: Stopping supervisor: supervisord.
Starting supervisor:

FATAL: all hosts have already failed -- aborting
```

Ultimately this appears to be a race condition between stopping the service, and then attempting to start it again before it actually completed stopping. It seems to send the stop signal and then immediately assume it's stopped.

```
2016-04-19 16:10:13,464 WARN received SIGTERM indicating exit request
2016-04-19 16:10:13,465 INFO waiting for fulfillment-data-entry-bridge to die
2016-04-19 16:10:13,873 INFO stopped: fulfillment-data-entry-bridge (exit status 143)
```

This change here adds a delay between the stop and start phases of the service restart. Quote from [docs](http://docs.ansible.com/ansible/service_module.html):

> If the service is being `restarted` then sleep this many seconds between the stop and start command. This helps to workaround badly behaving init scripts that exit immediately after signaling a process to stop.

I've chosen the default sleep to be 5 seconds, which is what the supervisor init.d script would do, if ansible were set up to actually use that for the restart. Since the current behavior is broken in my opinion, I think this is better than making it backwards compatible and defaulting to nothing. But if people disagree I can change that, and just update my deployments to supply the new configuration option.

Related info:
http://stackoverflow.com/questions/32738415/supervisor-fails-to-restart-half-of-the-time
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805920